### PR TITLE
Fixing #557 - correct to QgsRectangle class

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/composer.rst
+++ b/source/docs/pyqgis_developer_cookbook/composer.rst
@@ -40,7 +40,7 @@ and do the rendering
   render.setLayerSet(lst)
 
   # set extent
-  rect = QgsRect(render.fullExtent())
+  rect = QgsRectangle(render.fullExtent())
   rect.scale(1.1)
   render.setExtent(rect)
 


### PR DESCRIPTION
Fix for issue #557 - use QgsRectangle rather than QgsRect in map export example (it appears QgsRect was the correct class in much older pre 2.0 QGIS versions).
