### PR TITLE
fix for #558: to produce correct-res image outputs

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/composer.rst
+++ b/source/docs/pyqgis_developer_cookbook/composer.rst
@@ -221,9 +221,7 @@ The following code fragment shows how to render a composition to a raster image
 
   # render the composition
   imagePainter = QPainter(image)
-  sourceArea = QRectF(0, 0, c.paperWidth(), c.paperHeight())
-  targetArea = QRectF(0, 0, width, height)
-  c.render(imagePainter, targetArea, sourceArea)
+  c.renderPage( imagePainter, 0 )
   imagePainter.end()
 
   image.save("out.png", "png")


### PR DESCRIPTION
See #558 :- proposed change to image export example for QgsComposition, so that maps in the exported images are produced at the correct resolution (rather than quite low-res).
